### PR TITLE
Strike weight ratio measure and analysis

### DIFF
--- a/src/components/charts/StrikeWeightRatioChart.tsx
+++ b/src/components/charts/StrikeWeightRatioChart.tsx
@@ -1,0 +1,34 @@
+import type { TouchWeightKeyData } from '@/lib/piano/touch-design/touch-weight-data.requirements';
+import {
+  TouchDesignChart,
+  TouchDesignSerieVariant,
+  type TouchDesignSerie,
+} from './TouchDesignChart';
+
+export interface StrikeWeightRatioChartProps {
+  keysData: TouchWeightKeyData[];
+  chartHeight: number;
+}
+
+export const StrikeWeightRatioChart = (props: StrikeWeightRatioChartProps) => {
+  const strikeWeightRatio = props.keysData.map<number | undefined>(
+    (key) => key.strikeWeightRatio ?? undefined,
+  );
+
+  const series: TouchDesignSerie[] = [
+    {
+      data: strikeWeightRatio,
+      name: 'Strike Weight Ratio',
+      variant: TouchDesignSerieVariant.Measured,
+    },
+  ];
+
+  return (
+    <TouchDesignChart
+      title="Strike Weight Ratio"
+      chartHeight={props.chartHeight}
+      series={series}
+      yAxisName="Strike Weight Ratio"
+    />
+  );
+};

--- a/src/components/measures/KeyMeasurement.tsx
+++ b/src/components/measures/KeyMeasurement.tsx
@@ -6,6 +6,12 @@ import { useCallback } from 'react';
 import { MeasureInputField } from './MeasureInputField';
 import { useKeyMeasures, useMeasureActions } from '@/hooks/use-measure-store';
 import { useKeyTabIndex } from '@/hooks/use-key-tab-index';
+import {
+  ArrowDownFromLine,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Hammer,
+} from 'lucide-react';
 
 export interface KeyMeasurementProps {
   keyNumber: number;
@@ -31,11 +37,48 @@ export const KeyMeasurement: React.FC<KeyMeasurementProps> = ({
     ['strikeWeight'],
   ]);
 
-  const placeholders: { [key in keyof KeyMeasureRequirements]: string } = {
-    downWeight: 'D',
-    frontWeight: 'FW',
-    strikeWeight: 'SW',
-    upWeight: 'U',
+  const measureSpecs: {
+    [key in keyof KeyMeasureRequirements]: {
+      placeholder: string;
+      tooltip: string | React.ReactNode;
+    };
+  } = {
+    downWeight: {
+      placeholder: 'D',
+      tooltip: (
+        <div className="flex items-center gap-2">
+          <ArrowDownToLine className="w-3 h-3 stroke-3" />
+          Down Weight (g)
+        </div>
+      ),
+    },
+    frontWeight: {
+      placeholder: 'FW',
+      tooltip: (
+        <div className="flex items-center gap-2">
+          <ArrowDownFromLine className="w-3 h-3 stroke-3" />
+          Front Weight (g)
+        </div>
+      ),
+    },
+    strikeWeight: {
+      placeholder: 'SW',
+      tooltip: (
+        <div className="flex items-center gap-2">
+          <Hammer className="w-3 h-3 stroke-3" />
+          Strike Weight (g)
+        </div>
+      ),
+    },
+    upWeight: {
+      placeholder: 'U',
+      tooltip: (
+        <div className="flex items-center gap-2">
+          <ArrowUpFromLine className="w-3 h-3 stroke-3" />
+          Up Weight (g)
+        </div>
+      ),
+    },
   };
 
   return (
@@ -50,7 +93,8 @@ export const KeyMeasurement: React.FC<KeyMeasurementProps> = ({
               key={property}
               defaultValue={keySpec[property]}
               onUpdate={onUpdateKeyProperty(property)}
-              placeholder={placeholders[property]}
+              placeholder={measureSpecs[property].placeholder}
+              tooltip={measureSpecs[property].tooltip}
               tabIndex={getTabIndexFor(property)}
             />
           ))}

--- a/src/components/measures/MeasureInputField.tsx
+++ b/src/components/measures/MeasureInputField.tsx
@@ -6,19 +6,23 @@ import { useValidatedNumericInputField } from '@/hooks/use-validated-numeric-inp
 import { cn } from '@/lib/utils';
 
 export interface MeasureInputFieldProps {
+  className?: string;
   defaultValue: OptionalNumber;
   onUpdate: (value: OptionalNumber) => void;
   validator?: Joi.Schema;
   placeholder?: string;
   tabIndex?: number;
+  tooltip?: string | React.ReactNode;
 }
 
 export const MeasureInputField: React.FC<MeasureInputFieldProps> = ({
+  className,
   defaultValue,
   placeholder,
   validator,
   onUpdate,
   tabIndex,
+  tooltip: tooltipContent,
 }) => {
   const { error, inputValue, onInputChange } = useValidatedNumericInputField(
     defaultValue,
@@ -32,6 +36,7 @@ export const MeasureInputField: React.FC<MeasureInputFieldProps> = ({
 
   const inputClassName = cn(
     'w-15 p-1 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-primary',
+    className,
     shouldShowErrorState &&
       'ring-1 ring-red-500 focus:ring-red-500 bg-red-100 text-red-900',
     shouldShowSuccessState &&
@@ -39,7 +44,7 @@ export const MeasureInputField: React.FC<MeasureInputFieldProps> = ({
   );
 
   return (
-    <Tooltip open={!!error && isFocused}>
+    <Tooltip open={isFocused && (!!error || !!tooltipContent)}>
       <TooltipTrigger asChild>
         <input
           type="text"
@@ -62,6 +67,11 @@ export const MeasureInputField: React.FC<MeasureInputFieldProps> = ({
           arrowClassName="bg-red-100 fill-red-100"
         >
           {error}
+        </TooltipContent>
+      )}
+      {isFocused && !error && !!tooltipContent && (
+        <TooltipContent textColor="text-background">
+          {tooltipContent}
         </TooltipContent>
       )}
     </Tooltip>

--- a/src/components/measures/PianoMeasureList.tsx
+++ b/src/components/measures/PianoMeasureList.tsx
@@ -3,8 +3,8 @@ import { MeasureInputField } from './MeasureInputField';
 import type { OptionalNumber } from '@/lib/piano/touch-design/measure-requirements';
 import { useCallback } from 'react';
 import {
-  DEFAULT_KEY_RATIO,
-  DEFAULT_WIPPEN_WEIGHT,
+  DEFAULT_KEY_WEIGHT_RATIO,
+  DEFAULT_WIPPEN_RADIUS_WEIGHT,
 } from '@/lib/piano/touch-design/constants';
 import Joi from 'joi';
 
@@ -19,9 +19,9 @@ export const PianoMeasureList = () => {
     [updateGlobalMeasure],
   );
 
-  const onUpdateWippenWeight = useCallback(
+  const onUpdateWippenRadiusWeight = useCallback(
     (value: OptionalNumber) => {
-      updateGlobalMeasure('wippenWeight', value);
+      updateGlobalMeasure('wippenRadiusWeight', value);
     },
     [updateGlobalMeasure],
   );
@@ -35,7 +35,7 @@ export const PianoMeasureList = () => {
             className="w-15"
             defaultValue={pianoMeasures.keyWeightRatio}
             onUpdate={onUpdateKeyRatio}
-            placeholder={DEFAULT_KEY_RATIO.toString()}
+            placeholder={DEFAULT_KEY_WEIGHT_RATIO.toString()}
             validator={Joi.number().min(0.1).max(1).optional()}
           />
         </div>
@@ -46,9 +46,9 @@ export const PianoMeasureList = () => {
         <div>
           <MeasureInputField
             className="w-15"
-            defaultValue={pianoMeasures.wippenWeight}
-            onUpdate={onUpdateWippenWeight}
-            placeholder={DEFAULT_WIPPEN_WEIGHT.toString()}
+            defaultValue={pianoMeasures.wippenRadiusWeight}
+            onUpdate={onUpdateWippenRadiusWeight}
+            placeholder={DEFAULT_WIPPEN_RADIUS_WEIGHT.toString()}
           />
         </div>
       </div>

--- a/src/components/measures/PianoMeasureList.tsx
+++ b/src/components/measures/PianoMeasureList.tsx
@@ -1,0 +1,57 @@
+import { useMeasureActions, usePianoMeasures } from '@/hooks/use-measure-store';
+import { MeasureInputField } from './MeasureInputField';
+import type { OptionalNumber } from '@/lib/piano/touch-design/measure-requirements';
+import { useCallback } from 'react';
+import {
+  DEFAULT_KEY_RATIO,
+  DEFAULT_WIPPEN_WEIGHT,
+} from '@/lib/piano/touch-design/constants';
+import Joi from 'joi';
+
+export const PianoMeasureList = () => {
+  const pianoMeasures = usePianoMeasures();
+  const { updateGlobalMeasure } = useMeasureActions();
+
+  const onUpdateKeyRatio = useCallback(
+    (value: OptionalNumber) => {
+      updateGlobalMeasure('keyWeightRatio', value);
+    },
+    [updateGlobalMeasure],
+  );
+
+  const onUpdateWippenWeight = useCallback(
+    (value: OptionalNumber) => {
+      updateGlobalMeasure('wippenWeight', value);
+    },
+    [updateGlobalMeasure],
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-row gap-10 flex-wrap items-center hover:bg-purple-50 p-2 px-3 max-w-fit">
+        <h3 className="text-sm font-bold w-40">Key weight ratio</h3>
+        <div>
+          <MeasureInputField
+            className="w-15"
+            defaultValue={pianoMeasures.keyWeightRatio}
+            onUpdate={onUpdateKeyRatio}
+            placeholder={DEFAULT_KEY_RATIO.toString()}
+            validator={Joi.number().min(0.1).max(1).optional()}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-row gap-10 flex-wrap items-center hover:bg-purple-50 p-2 px-3 max-w-fit">
+        <h3 className="text-sm font-bold w-40">Wippen radius weight</h3>
+        <div>
+          <MeasureInputField
+            className="w-15"
+            defaultValue={pianoMeasures.wippenWeight}
+            onUpdate={onUpdateWippenWeight}
+            placeholder={DEFAULT_WIPPEN_WEIGHT.toString()}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/pages/AnalyzePage.tsx
+++ b/src/components/pages/AnalyzePage.tsx
@@ -11,6 +11,7 @@ import { useInjection } from 'inversify-react';
 import { useMemo } from 'react';
 import { StrikeWeightChart } from '../charts/StrikeWeightChart';
 import { useChartDimension } from '../charts/hooks/use-chart-dimension';
+import { StrikeWeightRatioChart } from '../charts/StrikeWeightRatioChart';
 
 export const AnalyzePage = () => {
   const { chartHeight } = useChartDimension();
@@ -40,6 +41,13 @@ export const AnalyzePage = () => {
 
         <section>
           <StrikeWeightChart chartHeight={chartHeight} />
+        </section>
+
+        <section>
+          <StrikeWeightRatioChart
+            chartHeight={chartHeight}
+            keysData={touchWeightData.keys}
+          />
         </section>
       </div>
     </MainLayout>

--- a/src/components/pages/MeasuresPage.tsx
+++ b/src/components/pages/MeasuresPage.tsx
@@ -1,6 +1,7 @@
 import { MainLayout } from '../MainLayout';
 import { Scale } from 'lucide-react';
 import { KeyMeasureList } from '../measures/KeyMeasureList';
+import { PianoMeasureList } from '../measures/PianoMeasureList';
 
 export const MeasurePage = () => {
   return (
@@ -8,7 +9,13 @@ export const MeasurePage = () => {
       <section className="container p-6">
         <div className="flex flex-col gap-5">
           <div className="relative flex flex-col gap-5">
+            <h2 className="text-xl font-bold">For each note</h2>
             <KeyMeasureList />
+          </div>
+
+          <div className="flex flex-col gap-5">
+            <h2 className="text-xl font-bold">For the whole piano</h2>
+            <PianoMeasureList />
           </div>
         </div>
       </section>

--- a/src/hooks/backup/use-import-measures.ts
+++ b/src/hooks/backup/use-import-measures.ts
@@ -42,7 +42,7 @@ export const useImportMeasures = () => {
         measuresStore.setState({
           keyWeightRatio: parsed.data.keyWeightRatio,
           keys: nextKeys,
-          wippenWeight: parsed.data.wippenWeight,
+          wippenRadiusWeight: parsed.data.wippenRadiusWeight,
         });
         toast.success('Import completed');
         return true;

--- a/src/hooks/use-measure-store.ts
+++ b/src/hooks/use-measure-store.ts
@@ -26,7 +26,7 @@ interface MeasuresStoreActions {
   updateGlobalMeasure: (
     property: keyof Pick<
       MeasureRequirements,
-      'keyWeightRatio' | 'wippenWeight'
+      'keyWeightRatio' | 'wippenRadiusWeight'
     >,
     value: OptionalNumber,
   ) => void;
@@ -69,7 +69,7 @@ const createMeasuresStore = (
 
         version: 1,
 
-        wippenWeight: null,
+        wippenRadiusWeight: null,
       }),
       {
         name: `piano-touch.measures.${measureProfileName}`,
@@ -77,7 +77,7 @@ const createMeasuresStore = (
           keyWeightRatio: state.keyWeightRatio,
           keys: state.keys,
           version: state.version,
-          wippenWeight: state.wippenWeight,
+          wippenRadiusWeight: state.wippenRadiusWeight,
         }),
       },
     ),
@@ -114,7 +114,7 @@ export const usePianoMeasures = (measureProfileName?: string) => {
     useShallow<MeasuresStore, MeasureRequirements>((state: MeasuresStore) => ({
       keyWeightRatio: state.keyWeightRatio,
       keys: state.keys,
-      wippenWeight: state.wippenWeight,
+      wippenRadiusWeight: state.wippenRadiusWeight,
     })),
   );
 };

--- a/src/lib/backup/measure-backup.ts
+++ b/src/lib/backup/measure-backup.ts
@@ -17,7 +17,7 @@ export const makeDataSchema = (expectedLength: number) =>
     .object({
       keyWeightRatio: OptionalNumberSchema,
       keys: z.array(KeyMeasureSchema).length(expectedLength),
-      wippenWeight: OptionalNumberSchema,
+      wippenRadiusWeight: OptionalNumberSchema,
     })
     .strict();
 

--- a/src/lib/piano/touch-design/constants.ts
+++ b/src/lib/piano/touch-design/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_KEY_RATIO = 0.5;
+export const DEFAULT_WIPPEN_WEIGHT = 18;

--- a/src/lib/piano/touch-design/constants.ts
+++ b/src/lib/piano/touch-design/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_KEY_RATIO = 0.5;
-export const DEFAULT_WIPPEN_WEIGHT = 18;
+export const DEFAULT_KEY_WEIGHT_RATIO = 0.5;
+export const DEFAULT_WIPPEN_RADIUS_WEIGHT = 18;

--- a/src/lib/piano/touch-design/measure-requirements.ts
+++ b/src/lib/piano/touch-design/measure-requirements.ts
@@ -10,5 +10,5 @@ export interface KeyMeasureRequirements {
 export interface MeasureRequirements {
   keys: KeyMeasureRequirements[];
   keyWeightRatio: OptionalNumber;
-  wippenWeight: OptionalNumber;
+  wippenRadiusWeight: OptionalNumber;
 }

--- a/src/lib/piano/touch-design/touch-weight-analyzer.ts
+++ b/src/lib/piano/touch-design/touch-weight-analyzer.ts
@@ -1,3 +1,7 @@
+import {
+  DEFAULT_KEY_WEIGHT_RATIO,
+  DEFAULT_WIPPEN_RADIUS_WEIGHT,
+} from './constants';
 import type {
   KeyMeasureRequirements,
   MeasureRequirements,
@@ -11,22 +15,40 @@ import type {
 
 export class TouchWeightAnalyzer implements TouchWeightAnalyzerRequirements {
   public analyze(input: MeasureRequirements): TouchWeightDataRequirements {
+    const keyWeightRatio = input.keyWeightRatio ?? DEFAULT_KEY_WEIGHT_RATIO;
+    const wippenRadiusWeight =
+      input.wippenRadiusWeight ?? DEFAULT_WIPPEN_RADIUS_WEIGHT;
+    const wippenBalanceWeight = this.computeWippenBalanceWeight(
+      keyWeightRatio,
+      wippenRadiusWeight,
+    );
     return {
-      keyWeightRatio: input.keyWeightRatio,
+      keyWeightRatio,
       keys: input.keys.map((keyMeasurements) =>
-        this.analyzeKey(keyMeasurements),
+        this.analyzeKey(keyMeasurements, wippenBalanceWeight),
       ),
-      wippenWeight: input.wippenWeight,
+      wippenBalanceWeight,
+      wippenRadiusWeight,
     };
   }
 
   private analyzeKey(
     keyMeasurements: KeyMeasureRequirements,
+    wippenBalanceWeight: number,
   ): TouchWeightKeyData {
+    const balanceWeight = this.computeBalanceWeight(keyMeasurements);
+    const frictionWeight = this.computeFrictionWeight(keyMeasurements);
+    const strikeWeightRatio = this.computeStrikeWeightRatio(
+      keyMeasurements,
+      balanceWeight,
+      wippenBalanceWeight,
+    );
+
     return {
       ...keyMeasurements,
-      balanceWeight: this.computeBalanceWeight(keyMeasurements),
-      frictionWeight: this.computeFrictionWeight(keyMeasurements),
+      balanceWeight,
+      frictionWeight,
+      strikeWeightRatio,
     };
   }
 
@@ -52,5 +74,26 @@ export class TouchWeightAnalyzer implements TouchWeightAnalyzerRequirements {
     }
 
     return (downWeight - upWeight) / 2;
+  }
+
+  private computeStrikeWeightRatio(
+    keyMeasurements: KeyMeasureRequirements,
+    balanceWeight: OptionalNumber,
+    wippenBalanceWeight: number,
+  ): OptionalNumber {
+    const { frontWeight, strikeWeight } = keyMeasurements;
+
+    if (!strikeWeight || !frontWeight || !balanceWeight) {
+      return null;
+    }
+
+    return (frontWeight + balanceWeight - wippenBalanceWeight) / strikeWeight;
+  }
+
+  private computeWippenBalanceWeight(
+    keyWeightRatio: number,
+    wippenRadiusWeight: number,
+  ): number {
+    return keyWeightRatio * wippenRadiusWeight;
   }
 }

--- a/src/lib/piano/touch-design/touch-weight-data.requirements.ts
+++ b/src/lib/piano/touch-design/touch-weight-data.requirements.ts
@@ -7,8 +7,10 @@ import type {
 export interface TouchWeightKeyData extends KeyMeasureRequirements {
   balanceWeight: OptionalNumber;
   frictionWeight: OptionalNumber;
+  strikeWeightRatio: OptionalNumber;
 }
 
 export interface TouchWeightDataRequirements extends MeasureRequirements {
   keys: TouchWeightKeyData[];
+  wippenBalanceWeight: number;
 }


### PR DESCRIPTION
- add KR (key weight ratio) an WW (whippen radius weight) fields on the measure page
- compute R (strike weight ratio) in TouchWeightAnalyzer
- add strike weight ratio (R) chart on analyze page