### PR TITLE
🐛 update charts after importing file

### DIFF
--- a/src/hooks/backup/use-import-measures.ts
+++ b/src/hooks/backup/use-import-measures.ts
@@ -42,7 +42,7 @@ export const useImportMeasures = () => {
             wippenRadiusWeight: k.wippenRadiusWeight ?? null,
           }));
 
-        measuresStore.setState({
+        measuresStore.getState().updateState({
           keyWeightRatio: parsed.data.keyWeightRatio ?? null,
           keys: nextKeys,
           wippenRadiusWeight: parsed.data.wippenRadiusWeight ?? null,

--- a/src/hooks/use-measure-store.ts
+++ b/src/hooks/use-measure-store.ts
@@ -42,6 +42,7 @@ interface MeasuresStoreActions {
     property: keyof GlobalMeasures,
     value: OptionalNumber,
   ) => void;
+  updateState: (newState: MeasuresStoreState) => void;
 }
 
 type MeasuresStore = VersionedMeasuresStoreState & MeasuresStoreActions;
@@ -66,23 +67,20 @@ const createMeasuresStore = (
           set(() => ({
             [property]: value,
           })),
-
         updateKeyMeasure: (keyIndex, property, value) =>
           set((state) => ({
             keys: state.keys.map((spec, index) =>
               index === keyIndex ? { ...spec, [property]: value } : spec,
             ),
           })),
-
         updateKeyMeasures: (keyIndex, keySpec) =>
           set((state) => ({
             keys: state.keys.map((spec, index) =>
               index === keyIndex ? keySpec : spec,
             ),
           })),
-
+        updateState: (newState: MeasuresStoreState) => set(() => newState),
         version: 1,
-
         wippenRadiusWeight: null,
       }),
       {


### PR DESCRIPTION

When using the import feature, the measurements are successfully imported into the Zustand store, but the graphs on the AnalyzePage are not updated to display the new data.

The root cause was that the import function was using measuresStore.setState() directly, which doesn't trigger React re-renders for components using Zustand hooks.